### PR TITLE
Fixed error issue in basic_widget.html sample

### DIFF
--- a/example/basic_widget.html
+++ b/example/basic_widget.html
@@ -34,7 +34,7 @@
 
     <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="   crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.qrcode/1.0/jquery.qrcode.min.js"></script>
-    <script src="https://cdn.auth0.com/js/guardian-js/0.2.0/guardian-js.js"></script>
+    <script src="https://cdn.auth0.com/js/guardian-js/0.4.0/guardian-js.js"></script>
 
     <style>
       .hidden {


### PR DESCRIPTION
When running the sample as is, the error `auth0GuardianJS.formPostHelper is not a function` is thrown. Updating guardian.js from `0.2.0` to `0.4.0` fixes this issue.